### PR TITLE
Fix/systemd cmdline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.2
+
+* Fixed the systemd kernel command line getting duplicated when ran multiple times.
+* Documented support for PVE 7.3 in meta.
+
 ## v1.0.1
 
 * The role now automatically detects the CPU type (`intel`/`amd`) of the system to generate the appropriate cmdline.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   platforms:
     - name: Proxmox VE
       versions:
+        - 7.3
         - 7.2
         - 7.1
         - 6.4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
       register: __cmdline_old
       ansible.builtin.shell:
         cmd: cat /etc/kernel/cmdline
-    
+
     - name: Write new cmdline
       when: __cmdline not in __cmdline_old.stdout
       ansible.builtin.copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,13 +50,12 @@
       changed_when: false
       failed_when: false
       register: __cmdline_old
-      ansible.builtin.command:
-        cmd: cat /etc/kernel/cmdline && rm /etc/kernel/cmdline
-
+      ansible.builtin.shell:
+        cmd: cat /etc/kernel/cmdline
+    
     - name: Write new cmdline
       when: __cmdline not in __cmdline_old.stdout
-      ansible.builtin.lineinfile:
-        path: /etc/kernel/cmdline
-        line: "{{ __cmdline_old.stdout }} {{ __cmdline }}"
-        create: true
+      ansible.builtin.copy:
+        dest: /etc/kernel/cmdline
+        content: "{{ __cmdline_old.stdout }} {{ __cmdline }}\n"
       notify: EFI Refresh


### PR DESCRIPTION
# Description

When ran on systemd based systems, the kernel commandline was getting duplicated so IOMMU support was not properly set up.

## Related Issues

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

# Developer Checklist:

- [x] README is up to date
- [x] CHANGELOG is up to date
- [x] All tests (CI and/or manual) have passed
- [x] Any dependent changes have been merged and published in downstream modules

# Reviewer Checklist:

- [x] README is up to date
- [x] CHANGELOG is up to date
- [x] All tests (CI and/or manual) have passed
- [x] Source and Target branches have been verified
- [x] `Squash and Merge` is selected as opposed to regular merge
- [x] Source branch has been removed after the merge
